### PR TITLE
Azure 저장소 의존성에 필요한 기본 환경 변수 추가

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,9 @@ services:
       - db
       - rabbitmq
     environment:
+      SPRING_CLOUD_AZURE_CREDENTIAL_MANAGED_IDENTITY_ENABLED: false
+      SPRING_CLOUD_AZURE_CREDENTIAL_CLIENT_ID: ""
+      SPRING_CLOUD_AZURE_STORAGE_BLOB_ACCOUNT_NAME: ""
       CLOUD_GCP_CREDENTIALS_JSON: |
         {
           "type": "service_account",


### PR DESCRIPTION
설치형 환경에서 사용하지는 않지만 기본 의존성 로드에 필요해 추가합니다.